### PR TITLE
Configure the postgresql archive adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,48 +12,18 @@ Set up common prometheus configurations
 
 ## Requirements
 
-### For postgres_exporter
+### For prometheus-postgresql-adapter
 
-Set up permission for the prometheus user (by default) to have access to the necessary stats
-
-```sql
-CREATE USER prometheus;
-ALTER USER prometheus SET SEARCH_PATH TO prometheus,pg_catalog;
-
--- If deploying as non-superuser (for example in AWS RDS)
--- GRANT prometheus TO :MASTER_USER;
-CREATE SCHEMA prometheus AUTHORIZATION prometheus;
-
-CREATE VIEW prometheus.pg_stat_activity
-AS
-  SELECT * from pg_catalog.pg_stat_activity;
-
-GRANT SELECT ON prometheus.pg_stat_activity TO prometheus;
-
-CREATE VIEW prometheus.pg_stat_replication AS
-  SELECT * from pg_catalog.pg_stat_replication;
-
-GRANT SELECT ON prometheus.pg_stat_replication TO prometheus;
-```
+* PostgreSQL 10
+* A PostgreSQL user that has full permissions on the database prometheus will be using
+* This assumes a local connection
 
 ## Role Variables
 
 - `prometheus_version` - Which version of prometheus to download
 - `prometheus_checksum` - The checksum for the version of prometheus
-- `node_exporter_version` - Which version of node exporter to download
-- `node_exporter_checksum` - The checksum for the version of node exporter
 - `alertmanager_version` - Which version of alertmanager to download
 - `alertmanager_checksum` - The checksum for the version of alertmanager
-- `redis_exporter_version` - Which version of redis_exporter to download
-- `redis_exporter_checksum` - The checksum for the version of redis_exporter
-- `postgres_exporter_version` - Which version of postgres_exporter to download
-- `postgres_exporter_checksum` - The checksum for the version of postgres_exporter
-- `postgres_exporter_connection_host` - The host to connect to
-  - Default: `/var/run/postgresql/` to use the default postgres socket
-- `postgres_exporter_connection_ssl_mode` - If to use ssl when connecting
-  - Default: `disable` - because the default is socket connection
-- `postgres_exporter_connection_user` -
-  - Default: `prometheus` - the connecting user (uses identity be default)
 - `grafana_ini_file` - The file to use for `grafana.ini`
   - Default: `grafana.ini`
 - `prometheus_config_file` - The file to use for `prometheus.yml`
@@ -63,6 +33,12 @@ GRANT SELECT ON prometheus.pg_stat_replication TO prometheus;
 - `alertmanager_enabled` - boolean - True for enabling the alertmanager, via systemctl
   - Default: `true`
 - `prometheus` - Configure scrape files, alert rules, and alert templates
+- `prometheus_postgresql_archive` - boolean - If true the postgresql adapter will be installed
+  - Default: `false`
+- `prometheus_postgresql_database` - Database that the adapter will use
+  - Default: `metrics`
+- `prometheus_postgresql_username` - User that the adapter will connect as
+  - Default: `prometheus`
 
 ## Dependencies
 
@@ -74,6 +50,10 @@ None
 grafana_ini_file: "{{ playbook_dir }}/files/grafana.ini"
 prometheus_config_file: "{{ playbook_dir }}/files/prometheus.yml"
 prometheus_alert_file: "{{ playbook_dir }}/files/alertmanager.yml"
+
+prometheus_postgresql_archive: true
+prometheus_postgresql_database: metrics
+prometheus_postgresql_username: prometheus
 
 prometheus:
   jobs:
@@ -93,30 +73,6 @@ Full setup:
 - hosts: servers
   roles:
     - { role: prometheus, action: "full" }
-```
-
-Node exporter only:
-
-```yaml
-- hosts: servers
-  roles:
-    - { role: prometheus, action: "node_exporter" }
-```
-
-Redis exporter only:
-
-```yaml
-- hosts: servers
-  roles:
-    - { role: prometheus, action: "redis_exporter" }
-```
-
-Postgres exporter only:
-
-```yaml
-- hosts: servers
-  roles:
-    - { role: prometheus, action: "postgres_exporter" }
 ```
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,10 @@ prometheus_config_file: prometheus.yml
 prometheus_alert_file: alertmanager.yml
 alertmanager_enabled: true
 
+prometheus_postgresql_archive: false
+prometheus_postgresql_database: metrics
+prometheus_postgresql_username: prometheus
+
 prometheus:
   jobs: []
   alert:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -21,3 +21,9 @@
     state: restarted
   when: alertmanager_enabled == True
   become: true
+
+- name: restart prometheus-postgres-adapter
+  service:
+    name: prometheus-postgres-adapter
+    state: restarted
+  become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,5 @@
 - import_tasks: prometheus.yml
 - import_tasks: grafana.yml
 - import_tasks: alertmanager.yml
+- import_tasks: postgres.yml
+  when: prometheus_postgresql_archive

--- a/tasks/postgres.yml
+++ b/tasks/postgres.yml
@@ -1,0 +1,102 @@
+---
+
+- name: Install dependencies for timescaledb
+  action: >
+    {{ ansible_pkg_mgr }} name={{ item }} state=present update_cache=yes
+  with_items:
+    - cmake
+    - postgresql-server-dev-10
+  become: true
+
+- name: Check if timescaledb is installed
+  shell: test -f /usr/lib/postgresql/10/lib/timescaledb.so
+  ignore_errors: yes
+  register: timescaledb_installed
+  tags: timescaledb
+  changed_when: false
+
+- name: Clone timescaledb repo
+  git:
+    repo: "https://github.com/timescale/timescaledb.git"
+    dest: /opt/timescaledb
+    clone: yes
+  when: timescaledb_installed | failed
+  become: true
+
+- name: Bootstrap timescaledb
+  shell: rm -rf build/ && ./bootstrap
+  args:
+    chdir: /opt/timescaledb
+  when: timescaledb_installed | failed
+  become: true
+
+- name: Make timescaledb
+  make:
+    chdir: /opt/timescaledb/build
+  when: timescaledb_installed | failed
+  become: yes
+
+- name: Make install timescaledb
+  make:
+    chdir: /opt/timescaledb/build
+    target: install
+  when: timescaledb_installed | failed
+  become: yes
+
+- name: Check if pg_prometheus is installed
+  shell: test -f /usr/lib/postgresql/10/lib/pg_prometheus.so
+  ignore_errors: yes
+  register: pg_prometheus_installed
+  tags: pg_prometheus
+  changed_when: false
+
+- name: Clone pg_prometheus repo
+  git:
+    repo: "https://github.com/timescale/pg_prometheus.git"
+    dest: /opt/pg_prometheus
+    clone: yes
+  when: pg_prometheus_installed | failed
+  become: true
+
+- name: Make pg_prometheus
+  make:
+    chdir: /opt/pg_prometheus
+  when: pg_prometheus_installed | failed
+  become: yes
+
+- name: Make install pg_prometheus
+  make:
+    chdir: /opt/pg_prometheus
+    target: install
+  when: pg_prometheus_installed | failed
+  become: yes
+
+- name: "Create adapter folder"
+  file:
+    path: /home/prometheus/prometheus-postgres-adapter
+    state: directory
+    mode: 0700
+  become: yes
+  become_user: prometheus
+
+- name: Copy postgres adapter
+  copy:
+    src: prometheus-postgresql-adapter
+    dest: /home/prometheus/prometheus-postgres-adapter/
+    mode: 0700
+  become: yes
+  become_user: prometheus
+
+- name: Template out the service file
+  template:
+    src: prometheus-postgres-adapter.service.j2
+    dest: /etc/systemd/system/prometheus-postgres-adapter.service
+    mode: 0644
+  notify:
+    - reload systemd
+    - restart prometheus-postgres-adapter
+
+- name: Enable prometheus-postgres-adapter
+  systemd:
+    enabled: yes
+    name: prometheus-postgres-adapter

--- a/templates/prometheus-postgres-adapter.service.j2
+++ b/templates/prometheus-postgres-adapter.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Prometheus Server
+Documentation=https://prometheus.io/docs/introduction/overview/
+After=network-online.target
+
+[Service]
+User=prometheus
+Restart=on-failure
+WorkingDirectory=/home/prometheus/prometheus-postgres-adapter
+ExecStart=/home/prometheus/prometheus-postgres-adapter/prometheus-postgresql-adapter \
+                                -pg-database {{ prometheus_postgresql_database }} \
+                                -pg-user {{ prometheus_postgresql_username }}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Set up the postgresql write adapter for prometheus. This sets up the required components, an extension `pg_prometheus`, as well as an optional requirement of `timescaledb`. TimescaleDB adds timeseries support to postgres.